### PR TITLE
Update scripts, add konflux automation files

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,19 +1,8 @@
 FROM fedora:rawhide
-# Install the required packages
-RUN sudo dnf install vim openssl nginx curl oqsprovider crypto-policies-scripts tcpdump sed -y
-# Update the TEST-PQ subpolicy
-RUN update-crypto-policies --set DEFAULT:TEST-PQ
-# Patch crypto-policies to not support KYBER768
-#RUN sed -i 's/KYBER768//' /etc/crypto-policies/state/CURRENT.pol
-# Activate the oqsprovider
-RUN sed -i '/default = default_sect/a oqsprovider = oqs_sect' /etc/pki/tls/openssl.cnf
-COPY append_sed.sh /tmp/append_sed.sh
-RUN chmod +x /tmp/append_sed.sh
-RUN /tmp/append_sed.sh
-# Copy useful commmands
-COPY script.sh .
-# Copy README into the container
-COPY README.txt .
-# Run bash in the container
-CMD ["/bin/bash"]
 
+COPY setup.sh .
+RUN bash setup.sh
+
+COPY test.sh .
+
+CMD ["/bin/bash"]

--- a/append_sed.sh
+++ b/append_sed.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-sed -i '/activate = 1/ {
-a [oqs_sect]
-a activate = 1
-}' /etc/pki/tls/openssl.cnf
-

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: fedora
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/
+    - repoid: fedora-debug
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/debug/tree
+    - repoid: fedora-source
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree
+packages:
+  - liboqs
+  - openssl
+  - oqsprovider

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,0 +1,47 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/l/liboqs-0.10.1-3.fc42.x86_64.rpm
+    repoid: fedora
+    size: 261164
+    checksum: sha256:a65be806165f2bd3b62d78c781524b73a70b5eb75dd2c84d056b9964f1db24cf
+    name: liboqs
+    evr: 0.10.1-3.fc42
+    sourcerpm: liboqs-0.10.1-3.fc42.src.rpm
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/o/openssl-3.2.2-8.fc42.x86_64.rpm
+    repoid: fedora
+    size: 1169505
+    checksum: sha256:be8b623b6437ed7a75e4287c3a5f6cf2f627f4b5543ad7dc08725a89923bbf40
+    name: openssl
+    evr: 1:3.2.2-8.fc42
+    sourcerpm: openssl-3.2.2-8.fc42.src.rpm
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/o/oqsprovider-0.6.0-3.fc41.x86_64.rpm
+    repoid: fedora
+    size: 183176
+    checksum: sha256:647eacabe6cf00acaa32a83d493ba531b21be87caec43d39f86f09b110fce6ea
+    name: oqsprovider
+    evr: 0.6.0-3.fc41
+    sourcerpm: oqsprovider-0.6.0-3.fc41.src.rpm
+  source:
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/l/liboqs-0.10.1-3.fc42.src.rpm
+    repoid: fedora-source
+    size: 4198419
+    checksum: sha256:fd4f67382629fee103aa859da820fa962d072d55754e0cfbad716a29a23eb921
+    name: liboqs
+    evr: 0.10.1-3.fc42
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/o/openssl-3.2.2-8.fc42.src.rpm
+    repoid: fedora-source
+    size: 18058344
+    checksum: sha256:b175fadb77614ca74ab2d25aba0a0e35c689cfd12e77c25fca896db319d32c0c
+    name: openssl
+    evr: 1:3.2.2-8.fc42
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/o/oqsprovider-0.6.0-3.fc41.src.rpm
+    repoid: fedora-source
+    size: 210156
+    checksum: sha256:685bd4ebe7caeaee8f2ceff2488e43cfeafdbef856e6b2b876dd132b0b330074
+    name: oqsprovider
+    evr: 0.6.0-3.fc41
+  module_metadata: []

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,34 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+dnf -y install --no-allow-downgrade vim nginx curl openssl oqsprovider crypto-policies-scripts tcpdump sed
+
+update-crypto-policies --set DEFAULT:TEST-PQ
+
+sed -i '/default = default_sect/a oqsprovider = oqs_sect' /etc/pki/tls/openssl.cnf
+
+sed -i '/activate = 1/ {
+a [oqs_sect]
+a activate = 1
+}' /etc/pki/tls/openssl.cnf
+
 #OpenSSL key and certificates generation
 
 openssl ecparam -out p256.pem -name P-256
+
 openssl req -x509 -newkey ec:p256.pem -keyout root.key -out root.crt -subj /CN=localhost -batch -nodes -days 36500 -sha256
+
 #nginx configuration
 
 mkdir /etc/pki/nginx
+
 mkdir /etc/pki/nginx/private
+
 cp root.crt /etc/pki/nginx/server.crt
+
 cp root.key /etc/pki/nginx/private/server.key
+
 getent passwd nginx
+
 chown -R nginx: /etc/pki/nginx


### PR DESCRIPTION
This commit updates the setup script used for building the container image.

It also adds 2 files:
1. `rpms.in.yaml`: contains the packages of concern along with the dnf repos containing rpm builds, sources and metadata of said packages
2. `rpms.lock.yaml`: this file is generated by running the `rpm-lockfile-prototype` tool on rpms.in.yaml. Konflux-CI will run a Renovate job that will update rpms.lock.yaml whenever any of the packages mentioned in rpms.in.yaml gets updated in the DNF repos.

This commit combined with a quay.io trigger to build new images on every github push will enable a fully auomated workflow for updated PQ container image.