### PR TITLE
Add script start-multiple-containers.sh to start nginx server on multiple containers with custom nginx config files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-dnf upgrade --refresh -y && dnf install -y vim nginx curl openssl liboqs oqsprovider crypto-policies-scripts tcpdump sed
+dnf upgrade --refresh -y && dnf install -y pgrep vim nginx curl openssl liboqs oqsprovider crypto-policies-scripts tcpdump sed
 
 update-crypto-policies --set DEFAULT:TEST-PQ
 

--- a/start-multiple-containers.sh
+++ b/start-multiple-containers.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Check if correct arguments are provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <config-directory-path>"
+    exit 1
+fi
+
+CONFIG_DIR="$1"
+PORT=22000  # Starting port
+IMAGE="quay.io/qubip/pq-container:latest"  # Container image
+
+# Check if the provided config directory exists
+if [ ! -d "$CONFIG_DIR" ]; then
+    echo "Error: Directory '$CONFIG_DIR' does not exist."
+    exit 1
+fi
+
+# Kill all existing containers
+echo "Stopping and removing all existing containers..."
+podman ps -a -q | xargs -I {} podman rm -f {}
+
+echo "Starting containers using image: $IMAGE"
+
+for CONFIG in "$CONFIG_DIR"/*.conf; do
+    INSTANCE_NAME="nginx_$(basename "$CONFIG" .conf)"
+    ((PORT++))
+
+    # Ensure the correct permissions for the config file
+    chmod 644 "$CONFIG"
+
+    # Run the container with the updated image and port 443, ensuring Nginx stays in the foreground
+    podman run -d --name "$INSTANCE_NAME" \
+        -v "$CONFIG":/etc/nginx/nginx.conf:rw,z \
+        -p "$PORT":443 $IMAGE nginx -g "daemon off;"
+
+    echo "Started $INSTANCE_NAME on port $PORT with config $CONFIG"
+
+    # Check if Nginx is running inside the container using ps aux | grep nginx
+    echo "Checking if Nginx is running inside $INSTANCE_NAME..."
+
+    # Execute 'ps aux' and show the output for the grep nginx command
+    podman exec "$INSTANCE_NAME" ps aux | grep -q "nginx"
+
+    if [ $? -eq 0 ]; then
+        echo "Nginx is running inside $INSTANCE_NAME."
+    else
+        echo "Error: Nginx is not running inside $INSTANCE_NAME!"
+    fi
+
+    # Display the full output of 'ps aux | grep nginx'
+    echo "Displaying output of 'ps aux | grep nginx' for $INSTANCE_NAME:"
+    podman exec "$INSTANCE_NAME" ps aux | grep "nginx"
+done
+
+# Display running containers
+echo "All containers are running. Listing them below:"
+podman ps -a
+
+exit 0
+


### PR DESCRIPTION
Add script start-multiple-containers.sh to start nginx server on multiple containers with custom nginx config files

This script automates the process of deploying multiple nginx containers using custom configuration files. The script performs the following tasks:

1. **Stops and Removes Existing Containers**: Prior to starting new instances, the script ensures that all existing containers are stopped and removed.
2. **Starts Containers with nginx Configuration**: For each configuration file in the specified directory, a new container is started using the `quay.io/qubip/pq-container:latest` image. The nginx configuration file is mounted to the container, and the container is bound to a unique port.
3. **Checks if Nginx is Running**: The script verifies that Nginx is running in each container by executing `ps aux | grep nginx` and outputs the process list for inspection.
4. **Displays Running Containers**: After execution, the script lists all containers, including the ones started in the current session, using `podman ps -a`.

### **How to Use:**

1. Ensure `podman` is installed and running.
2. Prepare custom nginx configuration files and place them in a directory.
3. Provide appropriate permission using 'chmod +x start-multiple-containers.sh'
4. Run the script with the configuration directory as an argument: sh ./start-multiple-containers.sh /path/to/configs