### PR TITLE
Enable automated PRs for rpm updates

### DIFF
--- a/.tekton/rawhide-pull-request.yaml
+++ b/.tekton/rawhide-pull-request.yaml
@@ -189,6 +189,8 @@ spec:
       params:
       - name: input
         value: $(params.prefetch-input)
+      - name: dev-package-managers
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/rawhide-push.yaml
+++ b/.tekton/rawhide-push.yaml
@@ -186,6 +186,8 @@ spec:
       params:
       - name: input
         value: $(params.prefetch-input)
+      - name: dev-package-managers
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:


### PR DESCRIPTION
We need to enable `dev package managers` for rpm lock files to be updated automatically as that's currently not stable supported.

Ref: https://konflux-ci.dev/docs/building/prefetching-dependencies/#rpm