### PR TITLE
Containerfile: use fully qualified image name

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,5 @@
-FROM fedora:42
+# Use fully qualified name for rpm-manager
+FROM quay.io/fedora/fedora:42
 
 COPY setup.sh .
 RUN bash setup.sh


### PR DESCRIPTION
This is probably required for renovate / rpm manager to update the rpm lockfile, per the suggestion by Qixiang Wan (konflux support).