### PR TITLE
Switch main back to rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,8 +11,8 @@ jobs:
       failure_comment:
         message: "Tests failed."
     targets:
-      - fedora-42-x86_64
-      - fedora-42-aarch64
+      - fedora-rawhide-x86_64
+      - fedora-rawhide-aarch64
     tf_extra_params:
       environments:
         - os:

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Use fully qualified name for rpm-manager
-FROM quay.io/fedora/fedora:42
+FROM quay.io/fedora/fedora:rawhide
 
 COPY setup.sh .
 RUN bash setup.sh

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,11 +1,11 @@
 contentOrigin:
   repos:
     - repoid: fedora
-      baseurl: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/$basearch/os/
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/
     - repoid: fedora-debug
-      baseurl: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/$basearch/debug/tree
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/debug/tree
     - repoid: fedora-source
-      baseurl: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/source/tree
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree
 packages:
   - liboqs
   - openssl

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -2,46 +2,63 @@
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
-- arch: x86_64
+- arch: aarch64
   packages:
-  - url: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/x86_64/os/Packages/l/liboqs-0.12.0-4.fc42.x86_64.rpm
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/aarch64/os/Packages/l/liboqs-0.12.0-4.fc43.aarch64.rpm
     repoid: fedora
-    size: 181604
-    checksum: sha256:122183704ce0dc15ecd1680397a8ea5610fb6d5edd51c309170d9d96b127b533
+    size: 79543
+    checksum: sha256:9b9661eb2624e49eb37081be43cb0b91f8a6deea649c44dafbd3c95dd9fce25e
     name: liboqs
-    evr: 0.12.0-4.fc42
-    sourcerpm: liboqs-0.12.0-4.fc42.src.rpm
-  - url: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/x86_64/os/Packages/o/openssl-3.2.4-3.fc42.x86_64.rpm
+    evr: 0.12.0-4.fc43
+    sourcerpm: liboqs-0.12.0-4.fc43.src.rpm
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/aarch64/os/Packages/o/openssl-3.5.0-5.fc43.aarch64.rpm
     repoid: fedora
-    size: 1177466
-    checksum: sha256:edc99abfbfa4d292426d6dea02fb04934cae7d15a295a2429cfb8925463bc9ed
+    size: 1261444
+    checksum: sha256:f2a37b5e436b5281ddacd22a68fb5512eb79c8edf9e7b5dd1fd0932ccd7dae4c
     name: openssl
-    evr: 1:3.2.4-3.fc42
-    sourcerpm: openssl-3.2.4-3.fc42.src.rpm
-  - url: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/x86_64/os/Packages/o/oqsprovider-0.8.0-3.fc42.x86_64.rpm
-    repoid: fedora
-    size: 174949
-    checksum: sha256:76d9d180acf17812bf73a27a57d62d17bf9072fffa6ce20d782b231306429153
-    name: oqsprovider
-    evr: 0.8.0-3.fc42
-    sourcerpm: oqsprovider-0.8.0-3.fc42.src.rpm
+    evr: 1:3.5.0-5.fc43
+    sourcerpm: openssl-3.5.0-5.fc43.src.rpm
   source:
-  - url: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/source/tree/Packages/l/liboqs-0.12.0-4.fc42.src.rpm
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/l/liboqs-0.12.0-4.fc43.src.rpm
     repoid: fedora-source
     size: 7911991
-    checksum: sha256:7d69f6a406c8c580854106420ca9e3c18b054aa3fed5ccf4ad3868cb5fa3bdea
+    checksum: sha256:0fc3eee4da3d794e281707e61eb8855e785d85acbefea2df73d19a3a6a8ac885
     name: liboqs
-    evr: 0.12.0-4.fc42
-  - url: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/source/tree/Packages/o/openssl-3.2.4-3.fc42.src.rpm
+    evr: 0.12.0-4.fc43
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/o/openssl-3.5.0-5.fc43.src.rpm
     repoid: fedora-source
-    size: 18070261
-    checksum: sha256:0c3ce9c4f801983785b6e5f1f8bb044f8a54f322e3453fdff0a3d818b97db711
+    size: 53386429
+    checksum: sha256:e64e777fc9aafb20a4d4005d87a56b095dc8bf442e7021aa5c12fbd1e4157c59
     name: openssl
-    evr: 1:3.2.4-3.fc42
-  - url: https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/Everything/source/tree/Packages/o/oqsprovider-0.8.0-3.fc42.src.rpm
+    evr: 1:3.5.0-5.fc43
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/l/liboqs-0.12.0-4.fc43.x86_64.rpm
+    repoid: fedora
+    size: 181260
+    checksum: sha256:a80f56444c07887e2cfec76b9d056a4995bd90c8a67a2a2bc5f057c0bc7684cd
+    name: liboqs
+    evr: 0.12.0-4.fc43
+    sourcerpm: liboqs-0.12.0-4.fc43.src.rpm
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/x86_64/os/Packages/o/openssl-3.5.0-5.fc43.x86_64.rpm
+    repoid: fedora
+    size: 1284793
+    checksum: sha256:c74b06e9598e03ecb5618b993016c1413c58b16b296487372619c91c2f73a52b
+    name: openssl
+    evr: 1:3.5.0-5.fc43
+    sourcerpm: openssl-3.5.0-5.fc43.src.rpm
+  source:
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/l/liboqs-0.12.0-4.fc43.src.rpm
     repoid: fedora-source
-    size: 258070
-    checksum: sha256:6d44c4ef15dd63542e2aef0bd93ad7188b8302b3a792ea127019917f9697dfa5
-    name: oqsprovider
-    evr: 0.8.0-3.fc42
+    size: 7911991
+    checksum: sha256:0fc3eee4da3d794e281707e61eb8855e785d85acbefea2df73d19a3a6a8ac885
+    name: liboqs
+    evr: 0.12.0-4.fc43
+  - url: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/source/tree/Packages/o/openssl-3.5.0-5.fc43.src.rpm
+    repoid: fedora-source
+    size: 53386429
+    checksum: sha256:e64e777fc9aafb20a4d4005d87a56b095dc8bf442e7021aa5c12fbd1e4157c59
+    name: openssl
+    evr: 1:3.5.0-5.fc43
   module_metadata: []


### PR DESCRIPTION
Also includes aarch64 in rpms.lock.yaml for multi-arch builds.