### PR TITLE
test: adjustmets to run with f-42

### DIFF
--- a/client.expect
+++ b/client.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/expect
+set timeout 30
+spawn /bin/sh -c "$argv"
+
+expect {
+    "Verify return code:" { send "GET / HTTP/1.0\r\r" }
+    timeout { close; exit 6 }
+    eof { close; exit 7 }
+}
+
+expect {
+    -re "/(.|\n)*(HTTP\/1\.)(0|1)( 200 )(o|O)(k|K)(.|\n)*/" {
+        exp_continue
+    }
+    timeout { close; exit 8 }
+    eof { puts "expect: EOF" }
+}
+
+set info [wait]
+exit [lindex $info 3]

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -3,9 +3,15 @@ provision:
     how: container
 discover:
     how: shell
-execute:
-    how: tmt
+    tests:
+        - name: /default
+          framework: beakerlib
+          test:
+            ./test.sh
+prepare:
+    how: shell
     script: |
         cat /etc/fedora-release
         bash setup.sh
-        bash test.sh
+execute:
+    how: tmt

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-dnf upgrade --refresh -y && dnf install -y pgrep vim nginx curl openssl liboqs oqsprovider crypto-policies-scripts tcpdump sed
+dnf upgrade --refresh -y && dnf install -y pgrep vim nginx curl openssl liboqs oqsprovider crypto-policies-scripts tcpdump sed beakerlib expect
 
 update-crypto-policies --set DEFAULT:TEST-PQ
 
@@ -15,9 +15,11 @@ a activate = 1
 
 #OpenSSL key and certificates generation
 
+mkdir /etc/testing_keys
+
 openssl ecparam -out p256.pem -name P-256
 
-openssl req -x509 -newkey ec:p256.pem -keyout root.key -out root.crt -subj /CN=localhost -batch -nodes -days 36500 -sha256
+openssl req -x509 -newkey ec:p256.pem -keyout /etc/testing_keys/root.key -out /etc/testing_keys/root.crt -subj /CN=localhost -batch -nodes -days 36500 -sha256
 
 #nginx configuration
 
@@ -25,9 +27,9 @@ mkdir /etc/pki/nginx
 
 mkdir /etc/pki/nginx/private
 
-cp root.crt /etc/pki/nginx/server.crt
+cp /etc/testing_keys/root.crt /etc/pki/nginx/server.crt
 
-cp root.key /etc/pki/nginx/private/server.key
+cp /etc/testing_keys/root.key /etc/pki/nginx/private/server.key
 
 getent passwd nginx
 

--- a/test.sh
+++ b/test.sh
@@ -2,9 +2,14 @@
 
 #set -exo pipefail
 
-rpm -q crypto-policies-scripts liboqs openssl oqsprovider
-update-crypto-policies --show | grep TEST-PQ
-openssl list -providers | grep 'name: OpenSSL OQS Provider'
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+POLICY="$(update-crypto-policies --show)"
+PACKAGES="crypto-policies-scripts liboqs openssl curl expect oqsprovider"
+KEY="/etc/testing_keys/root.key" # created and stored during setup phase
+CRT="/etc/testing_keys/root.crt" # created and stored during setup phase
+SERVER_TXT="server_pid.txt"
 
 # Function to start openssl s_server and return its PID
 function start_s_server {
@@ -13,23 +18,25 @@ function start_s_server {
     local port=$3
 
     # Start openssl s_server in the background and capture its PID
-    openssl s_server -key "$key" -cert "$cert" -accept "$port" > /dev/null 2>&1 &
+    rlRun "openssl s_server -www -key "$key" -cert "$cert" -accept "$port" > /dev/null 2>&1 &"
     s_server_pid=$!
-    echo $s_server_pid
+    echo $s_server_pid > $SERVER_TXT
+    rlWaitForSocket 4433 -p $s_server_pid
+    rlLogInfo "The server started with the id $s_server_pid"
 }
 
 # Function to stop the openssl s_server process
 function stop_s_server {
-    local pid=$1
+    local pid=$(cat $SERVER_TXT)
 
     # Kill the openssl s_server process
     if [ -n "$pid" ]; then
+        rlLogInfo "Stopping openssl s_server with PID $pid..."
         kill "$pid" 2>/dev/null || true
-
-        # Wait for the process to terminate
-        wait "$pid" 2>/dev/null || true
+        rlWait $pid
+        rlLogInfo "Server stopped."
     else
-        echo "No PID provided or PID is empty."
+        rlLogWarning "No PID provided or PID is empty."
     fi
 }
 
@@ -38,122 +45,78 @@ function run_s_client_and_grep {
     local group=$1
     local host=$2
     local port=$3
-    local pattern=$4
-    local found=0  # Flag to check if the pattern was found
-    
-    # Run openssl s_client in the background, redirecting output to a temporary file
-    tmpfile=$(mktemp)
-    timeout 10s openssl s_client ${group} -connect ${host}:${port} -trace > "$tmpfile" 2>&1 &
-    s_client_pid=$!
-
-    echo "Running s_client on ${host}:${port}, searching for pattern: '${pattern}'"
-
-    # Monitor the output file for the pattern
-    while read -r line; do
-        echo "$line" | grep -q "$pattern"
-        if [ $? -eq 0 ]; then
-            echo "Pattern '${pattern}' found, terminating openssl s_client."
-            found=1
-            kill "$s_client_pid" 2>/dev/null || true
-            break
+    local patterns=$4
+    local regex_flag=$5
+    local modify=$6
+    rlRun -s "./client.expect openssl s_client -trace ${group} -connect ${host}:${port}" 0 "Run client"
+    if [ ! -z $modify ]; then
+        sed -i ':a;N;$!ba;s/using\r\n/using /g' $rlRun_LOG
         fi
-    done < <(timeout 15s tail -f "$tmpfile")  # Process substitution to avoid subshell issues
-
-    # Wait for the s_client process to exit
-    wait "$s_client_pid" 2>/dev/null || true
-
-    # If the pattern was not found, print an error message
-    if [ $found -eq 0 ]; then
-        echo "Error: Pattern '${pattern}' not found within the timeout period."
-	return 1
-    fi
-
-    # Cleanup
-    rm -f "$tmpfile"
+    local IFS=';'
+    for pattern in ${patterns[@]}; do
+        rlAssertGrep "$pattern" $rlRun_LOG $regex_flag
+    done
 }
 
-# OpenSSL client and server tests
+rlJournalStart
 
-# Start the server
-echo "Starting openssl s_server..."
-s_server_pid=$(start_s_server "root.key" "root.crt" 4433)
-echo "Server started with PID $s_server_pid"
+    rlPhaseStartSetup
+        rlAssertRpm --all $PACKAGES
+        rlRun -s "update-crypto-policies --show"
+        rlAssertGrep "TEST-PQ" $rlRun_LOG
+        rlRun -s "openssl list -providers"
+        rlAssertGrep "name: OpenSSL OQS Provider" $rlRun_LOG
+        rlRun "touch ${SERVER_TXT}"
+    rlPhaseEnd
 
-# Give the server some time to start (if needed)
-sleep 5
+    rlPhaseStartTest "TEST 1: Default connection with X25519MLKEM768"
+        start_s_server $KEY $CRT 4433
+        run_s_client_and_grep "" "localhost" "4433" "NamedGroup: X25519MLKEM768" "" ""
+        stop_s_server
+    rlPhaseEnd
 
-# TEST 1: Default connection with X25519MLKEM768
-run_s_client_and_grep "" "localhost" "4433" "NamedGroup: UNKNOWN (4588)"
+    rlPhaseStartTest "TEST 2: Specifying groups: SecP256r1MLKEM768 and X25519MLKEM768"
+        start_s_server $KEY $CRT 4433
+        rlLogInfo "Specify the group SecP256r1MLKEM768"
+        run_s_client_and_grep "-groups SecP256r1MLKEM768" "localhost" "4433" "Shared groups: SecP256r1MLKEM768" "" ""
+        rlLogInfo "Specify the group X25519MLKEM768"
+        run_s_client_and_grep "-groups X25519MLKEM768" "localhost" "4433" "Shared groups: X25519MLKEM768" "" ""
+        stop_s_server
+    rlPhaseEnd
 
-# Stop the server
-echo "Stopping openssl s_server with PID $s_server_pid..."
-stop_s_server "$s_server_pid"
-echo "Server stopped."
+    rlPhaseStartTest "TEST 3: Hybrid ML-KEM - TLS connection with oqs test server"
+        rlLogInfo "Connection with SecP256r1MLKEM768"
+        run_s_client_and_grep "" "test.openquantumsafe.org" "6001" 'CONNECTED\(00000003\);(Successfully connected using )([a-z]|[A-Z]|[0-9])*(-)*SecP256r1MLKEM768' "-P" "using"
+        rlLogInfo "Connection with X25519MLKEM768"
+        run_s_client_and_grep "" "test.openquantumsafe.org" "6003" 'CONNECTED\(00000003\);(Successfully connected using )([a-z]|[A-Z]|[0-9])*(-)*X25519MLKEM768' "-P" "using"
+    rlPhaseEnd
 
-# Start the server
-echo "Starting openssl s_server..."
-s_server_pid=$(start_s_server "root.key" "root.crt" 4433)
-echo "Server started with PID $s_server_pid"
+    rlPhaseStartTest "TEST 4: Tests with the nginx server"
+        rlRun "nginx"
+        run_s_client_and_grep "" "localhost" "443" "CONNECTED(00000003);NamedGroup: X25519MLKEM768" "" ""
+    rlPhaseEnd
 
-# Give the server some time to start (if needed)
-sleep 5
+    rlPhaseStartTest "TEST 5: Tests with curl"
+        rlRun "curl --cacert $CRT https://localhost:443/ -o /dev/null" 0 "Curl command exit status"
+    rlPhaseEnd
 
-# TEST 2: Specify the group explicitly
-# TEST 2.1: Specify the group SecP256r1MLKEM768
-run_s_client_and_grep "-groups SecP256r1MLKEM768" "localhost" "4433" "NamedGroup: UNKNOWN (4587)"
+    rlPhaseStartTest "TEST 6: List the supported ML-KEM algorithms"
+        rlRun -s "openssl list -kem-algorithms -provider oqsprovider"
+        rlAssertGrep "SecP256r1MLKEM768" $rlRun_LOG
+        rlAssertGrep "X25519MLKEM768" $rlRun_LOG
+    rlPhaseEnd
 
-# Stop the server
-echo "Stopping openssl s_server with PID $s_server_pid..."
-stop_s_server "$s_server_pid"
-echo "Server stopped."
+    rlPhaseStartTest "TEST 7: Testing a ML-DSA Key"
+        rlLogInfo "Generating a ML-DSA Key Pair"
+        rlRun "openssl genpkey -algorithm mldsa65 -out mldsa65_private.pem"
+        rlRun "openssl pkey -in mldsa65_private.pem -pubout -out mldsa65_public.pem"
+        rlLogInfo "Signing a raw message"
+        rlRun "seq 1 10 > message.txt"
+        rlRun "openssl dgst -sign mldsa65_private.pem -out signature.bin message.txt"
+        rlLogInfo "Verifying the signature"
+        rlRun -s "openssl dgst -verify mldsa65_public.pem -signature signature.bin message.txt"
+        rlAssertGrep "Verified OK" $rlRun_LOG
+    rlPhaseEnd
 
-# TEST 2.2: Specify the group X25519MLKEM768
-# Start the server
-echo "Starting openssl s_server..."
-s_server_pid=$(start_s_server "root.key" "root.crt" 4433)
-echo "Server started with PID $s_server_pid"
-
-run_s_client_and_grep "-groups X25519MLKEM768" "localhost" "4433" "NamedGroup: UNKNOWN (4588)"
-
-# Stop the server
-echo "Stopping openssl s_server with PID $s_server_pid..."
-stop_s_server "$s_server_pid"
-echo "Server stopped."
-
-# TEST 3: Tests with the external server
-# TEST 3.1: #Hybrid ML-KEM - SecP256r1MLKEM768 TLS connection with oqs test server
-run_s_client_and_grep "" "test.openquantumsafe.org" "6001" "CONNECTED(00000003)"
-run_s_client_and_grep "" "test.openquantumsafe.org" "6001" "NamedGroup: UNKNOWN (4587)"
-# TEST 3.2: #Hybrid ML-KEM - X25519MLKEM768 TLS connection with oqs test server
-run_s_client_and_grep "" "test.openquantumsafe.org" "6002" "CONNECTED(00000003)"
-run_s_client_and_grep "" "test.openquantumsafe.org" "6002" "NamedGroup: UNKNOWN (4588)"
-
-# TEST 4: Tests with the nginx server
-nginx
-run_s_client_and_grep "" "localhost" "443" "NamedGroup: UNKNOWN (4587)"
-run_s_client_and_grep "" "localhost" "443" "CONNECTED(00000003)"
-
-# TEST 5: Tests with curl
-# Execute curl command and capture the exit status
-curl --cacert root.crt https://localhost:443/ -o /dev/null
-if [ $? -eq 0 ]; then
-    echo "Curl command succeeded."
-else
-    echo "Curl command failed."
-fi
-
-# TEST 6: List the supported ML-KEM algorithms
-openssl list -kem-algorithms -provider oqsprovider | grep SecP256r1MLKEM768 || echo "Fail: SecP256r1MLKEM768 not found"
-openssl list -kem-algorithms -provider oqsprovider | grep X25519MLKEM768 ||  echo "Fail: X25519MLKEM768 not found"
-
-# TEST 7: Generate a ML-DSA Key Pair
-openssl genpkey -algorithm mldsa65 -out mldsa65_private.pem && ls  mldsa65_private.pem || echo "Fail: Private key not created"
-openssl pkey -in mldsa65_private.pem -pubout -out mldsa65_public.pem && ls mldsa65_public.pem || echo "Fail: Public key not created"
-
-# TEST 7.1: # sign a raw message
-touch message.txt
-seq 1 10 > message.txt
-openssl dgst -sha256 -sign mldsa65_private.pem -out signature.bin message.txt && ls signature.bin || echo "Fail: Signature not created"
-
-# TEST 7.2: # Verify the signature
-openssl dgst -sha256 -verify mldsa65_public.pem -signature signature.bin message.txt | grep "Verified OK" || echo "Fail: Verification failed"
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
The test is forked from [the pull request](https://github.com/QUBIP/pq-container/pull/32) to the main branch and is adjusted to the expected outputs of fedora-42: 
- first test:  default connection group: UNKNOWN (4588)
- third test: the searched output is placed in two lines, due to the fact that grep takes input line by line, the needed output is concatenated to be used by grep. 
